### PR TITLE
stepジョブで実行したnode_mosulesを次のジョブで保持できるようにする

### DIFF
--- a/articles/44977a5ea4d6cd.md
+++ b/articles/44977a5ea4d6cd.md
@@ -60,6 +60,10 @@ jobs:
           key: yarn-packages-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
+      - persist_to_workspace:
+          root: .
+          paths:
+            - '*'
   test:
     executor: default
     steps:

--- a/articles/44977a5ea4d6cd.md
+++ b/articles/44977a5ea4d6cd.md
@@ -63,7 +63,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - '*'
+            - node_modules/*
   test:
     executor: default
     steps:


### PR DESCRIPTION
こちらの記事大変参考になりました

> 今回のサンプルコードで実際に動作確認してないので、ちゃんと動かないかもしれません

実際に動かしてみたら所，`persist_to_workspace`でstepsジョブのファイルをちゃんと保持すればその後のジョブが動くようになったのでプルリクを作成をしてみました．
お時間あるときにご覧ください．
